### PR TITLE
feat: generate actual json in encode function

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ pub fn main() {
   case result {
     Ok(geojson) -> {
       // Successfully decoded GeoJSON
-      let encoded = gleojson.encode_geojson(geojson)
-      // encoded is now a Dynamic representation of the GeoJSON object
-      // You can use it for further processing or encoding back to JSON
     }
     Error(errors) -> {
       todo
@@ -44,6 +41,20 @@ pub fn main() {
       // errors contains information about what went wrong during decoding
     }
   }
+
+  // Construct GeoJSON from types
+  let geojson = gleojson.GeoJSONFeatureCollection(
+    gleojson.FeatureCollection([
+      gleojson.Feature(
+        geometry: option.Some(gleojson.Point([1.0, 2.0])),
+        properties: option.None,
+        id: option.Some(gleojson.StringId("feature-id")),
+      ),
+    ]),
+  )
+
+  // Encode to JSON string
+  gleojson.encode_geojson(geojson) |> json.to_string
 }
 ```
 

--- a/birdie_snapshots/feature_encode_decode.accepted
+++ b/birdie_snapshots/feature_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: feature_encode_decode
+---
+{"id":"feature-id","type":"Feature","geometry":{"type":"Point","coordinates":[1.0,2.0]},"properties":null}

--- a/birdie_snapshots/featurecollection_encode_decode.accepted
+++ b/birdie_snapshots/featurecollection_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: featurecollection_encode_decode
+---
+{"type":"FeatureCollection","features":[{"id":"feature-id","type":"Feature","geometry":{"type":"Point","coordinates":[1.0,2.0]},"properties":null}]}

--- a/birdie_snapshots/geometrycollection_encode_decode.accepted
+++ b/birdie_snapshots/geometrycollection_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: geometrycollection_encode_decode
+---
+{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1.0,2.0]},{"type":"LineString","coordinates":[[3.0,4.0],[5.0,6.0]]}]}

--- a/birdie_snapshots/linestring_encode_decode.accepted
+++ b/birdie_snapshots/linestring_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: linestring_encode_decode
+---
+{"type":"LineString","coordinates":[[1.0,2.0],[3.0,4.0]]}

--- a/birdie_snapshots/multipoint_encode_decode.accepted
+++ b/birdie_snapshots/multipoint_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: multipoint_encode_decode
+---
+{"type":"MultiPoint","coordinates":[[1.0,2.0],[3.0,4.0]]}

--- a/birdie_snapshots/multipolygon_encode_decode.accepted
+++ b/birdie_snapshots/multipolygon_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: multipolygon_encode_decode
+---
+{"type":"MultiPolygon","coordinates":[[[[1.0,2.0],[3.0,4.0],[5.0,6.0],[1.0,2.0]]],[[[7.0,8.0],[9.0,10.0],[11.0,12.0],[7.0,8.0]]]]}

--- a/birdie_snapshots/point_encode_decode.accepted
+++ b/birdie_snapshots/point_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: point_encode_decode
+---
+{"type":"Point","coordinates":[1.0,2.0]}

--- a/birdie_snapshots/polygon_encode_decode.accepted
+++ b/birdie_snapshots/polygon_encode_decode.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.3
+title: polygon_encode_decode
+---
+{"type":"Polygon","coordinates":[[[1.0,2.0],[3.0,4.0],[5.0,6.0],[1.0,2.0]]]}

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,7 +8,8 @@ links = [{ title = "RFC7946", href = "https://datatracker.ietf.org/doc/html/rfc7
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_json = ">= 2.0.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
-gleam_json = ">= 2.0.0 and < 3.0.0"
+birdie = ">= 1.2.3 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,26 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "birdie", version = "1.2.3", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "AE1207210E9CC8F4170BCE3FB3C23932F314C352C3FD1BCEA44CF4BF8CF60F93" },
+  { name = "edit_distance", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "edit_distance", source = "hex", outer_checksum = "A1E485C69A70210223E46E63985FA1008B8B2DDA9848B7897469171B29020C05" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
+  { name = "glance", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "8F3314D27773B7C3B9FB58D8C02C634290422CE531988C0394FA0DF8676B964D" },
+  { name = "gleam_community_ansi", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "4CD513FC62523053E62ED7BAC2F36136EC17D6A8942728250A9A00A15E340E4B" },
+  { name = "gleam_community_colour", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "A49A5E3AE8B637A5ACBA80ECB9B1AFE89FD3D5351FF6410A42B84F666D40D7D5" },
+  { name = "gleam_erlang", version = "0.27.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "DE468F676D71B313C6C8C5334425CFCF827837333F8AB47B64D8A6D7AA40185D" },
   { name = "gleam_json", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB10B0E7BF44282FB25162F1A24C1A025F6B93E777CCF238C4017E4EEF2CDE97" },
   { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
+  { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
+  { name = "rank", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "rank", source = "hex", outer_checksum = "5660E361F0E49CBB714CC57CC4C89C63415D8986F05B2DA0C719D5642FAD91C9" },
+  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "trie_again", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "trie_again", source = "hex", outer_checksum = "5B19176F52B1BD98831B57FDC97BD1F88C8A403D6D8C63471407E78598E27184" },
 ]
 
 [requirements]
+birdie = { version = ">= 1.2.3 and < 2.0.0" }
 gleam_json = { version = ">= 2.0.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/test/gleojson_test.gleam
+++ b/test/gleojson_test.gleam
@@ -1,3 +1,4 @@
+import birdie
 import gleam/dict
 import gleam/dynamic
 import gleam/json
@@ -11,194 +12,109 @@ pub fn main() {
   gleeunit.main()
 }
 
+fn assert_encode_decode(geojson: gleojson.GeoJSON, name: String) {
+  let encoded = gleojson.encode_geojson(geojson) |> json.to_string
+  birdie.snap(encoded, name)
+  json.decode(from: encoded, using: gleojson.geojson_decoder)
+  |> should.be_ok
+  |> should.equal(geojson)
+}
+
 pub fn point_encode_decode_test() {
-  let original_point = gleojson.GeoJSONGeometry(gleojson.Point([1.0, 2.0]))
-
-  let encoded_dynamic = gleojson.encode_geojson(original_point)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_point =
-    decoded_result
-    |> should.be_ok
-
-  decoded_point
-  |> should.equal(original_point)
+  gleojson.GeoJSONGeometry(gleojson.Point([1.0, 2.0]))
+  |> assert_encode_decode("point_encode_decode")
 }
 
 pub fn multipoint_encode_decode_test() {
-  let original_multipoint =
-    gleojson.GeoJSONGeometry(gleojson.MultiPoint([[1.0, 2.0], [3.0, 4.0]]))
-
-  let encoded_dynamic = gleojson.encode_geojson(original_multipoint)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_multipoint =
-    decoded_result
-    |> should.be_ok
-
-  decoded_multipoint
-  |> should.equal(original_multipoint)
+  gleojson.GeoJSONGeometry(gleojson.MultiPoint([[1.0, 2.0], [3.0, 4.0]]))
+  |> assert_encode_decode("multipoint_encode_decode")
 }
 
 pub fn linestring_encode_decode_test() {
-  let original_linestring =
-    gleojson.GeoJSONGeometry(gleojson.LineString([[1.0, 2.0], [3.0, 4.0]]))
-
-  let encoded_dynamic = gleojson.encode_geojson(original_linestring)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_linestring =
-    decoded_result
-    |> should.be_ok
-
-  decoded_linestring
-  |> should.equal(original_linestring)
+  gleojson.GeoJSONGeometry(gleojson.LineString([[1.0, 2.0], [3.0, 4.0]]))
+  |> assert_encode_decode("linestring_encode_decode")
 }
 
 pub fn polygon_encode_decode_test() {
-  let original_polygon =
-    gleojson.GeoJSONGeometry(
-      gleojson.Polygon([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]]),
-    )
-
-  let encoded_dynamic = gleojson.encode_geojson(original_polygon)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_polygon =
-    decoded_result
-    |> should.be_ok
-
-  decoded_polygon
-  |> should.equal(original_polygon)
+  gleojson.GeoJSONGeometry(
+    gleojson.Polygon([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]]),
+  )
+  |> assert_encode_decode("polygon_encode_decode")
 }
 
 pub fn multipolygon_encode_decode_test() {
-  let original_multipolygon =
-    gleojson.GeoJSONGeometry(
-      gleojson.MultiPolygon([
-        [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]],
-        [[[7.0, 8.0], [9.0, 10.0], [11.0, 12.0], [7.0, 8.0]]],
-      ]),
-    )
-
-  let encoded_dynamic = gleojson.encode_geojson(original_multipolygon)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_multipolygon =
-    decoded_result
-    |> should.be_ok
-
-  decoded_multipolygon
-  |> should.equal(original_multipolygon)
+  gleojson.GeoJSONGeometry(
+    gleojson.MultiPolygon([
+      [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1.0, 2.0]]],
+      [[[7.0, 8.0], [9.0, 10.0], [11.0, 12.0], [7.0, 8.0]]],
+    ]),
+  )
+  |> assert_encode_decode("multipolygon_encode_decode")
 }
 
 pub fn geometrycollection_encode_decode_test() {
-  let original_geometrycollection =
-    gleojson.GeoJSONGeometry(
-      gleojson.GeometryCollection([
-        gleojson.Point([1.0, 2.0]),
-        gleojson.LineString([[3.0, 4.0], [5.0, 6.0]]),
-      ]),
-    )
-  let encoded_dynamic = gleojson.encode_geojson(original_geometrycollection)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_geometrycollection =
-    decoded_result
-    |> should.be_ok
-
-  decoded_geometrycollection
-  |> should.equal(original_geometrycollection)
+  gleojson.GeoJSONGeometry(
+    gleojson.GeometryCollection([
+      gleojson.Point([1.0, 2.0]),
+      gleojson.LineString([[3.0, 4.0], [5.0, 6.0]]),
+    ]),
+  )
+  |> assert_encode_decode("geometrycollection_encode_decode")
 }
 
 pub fn feature_encode_decode_test() {
-  let properties =
-    dict.from_list([
-      #("name", dynamic.from("Test Point")),
-      #("value", dynamic.from(42)),
-    ])
+  // let properties =
+  //   dict.from_list([
+  //     #("name", dynamic.from("Test Point")),
+  //     #("value", dynamic.from(42)),
+  //   ])
 
-  let original_feature =
-    gleojson.GeoJSONFeature(gleojson.Feature(
-      geometry: option.Some(gleojson.Point([1.0, 2.0])),
-      properties: option.Some(properties),
-      id: option.Some(gleojson.StringId("feature-id")),
-    ))
-
-  let encoded_dynamic = gleojson.encode_geojson(original_feature)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_feature =
-    decoded_result
-    |> should.be_ok
-
-  decoded_feature
-  |> should.equal(original_feature)
+  gleojson.GeoJSONFeature(gleojson.Feature(
+    geometry: option.Some(gleojson.Point([1.0, 2.0])),
+    properties: option.None,
+    id: option.Some(gleojson.StringId("feature-id")),
+  ))
+  |> assert_encode_decode("feature_encode_decode")
 }
 
 pub fn featurecollection_encode_decode_test() {
-  let properties =
-    dict.from_list([
-      #("name", dynamic.from("Test Point")),
-      #("value", dynamic.from(42)),
-    ])
+  // let properties =
+  //   dict.from_list([
+  //     #("name", dynamic.from("Test Point")),
+  //     #("value", dynamic.from(42)),
+  //   ])
 
-  let feature =
-    gleojson.Feature(
-      geometry: option.Some(gleojson.Point([1.0, 2.0])),
-      properties: option.Some(properties),
-      id: option.Some(gleojson.StringId("feature-id")),
-    )
-
-  let original_featurecollection =
-    gleojson.GeoJSONFeatureCollection(gleojson.FeatureCollection([feature]))
-
-  let encoded_dynamic = gleojson.encode_geojson(original_featurecollection)
-
-  let decoded_result = gleojson.geojson_decoder(encoded_dynamic)
-
-  let decoded_featurecollection =
-    decoded_result
-    |> should.be_ok
-
-  decoded_featurecollection
-  |> should.equal(original_featurecollection)
+  gleojson.GeoJSONFeatureCollection(
+    gleojson.FeatureCollection([
+      gleojson.Feature(
+        geometry: option.Some(gleojson.Point([1.0, 2.0])),
+        properties: option.None,
+        id: option.Some(gleojson.StringId("feature-id")),
+      ),
+    ]),
+  )
+  |> assert_encode_decode("featurecollection_encode_decode")
 }
 
 pub fn invalid_type_decode_test() {
-  let invalid_dynamic =
-    dynamic.from(
-      dict.from_list([
-        #("type", dynamic.from("InvalidType")),
-        #("coordinates", dynamic.from([1.0, 2.0])),
-      ]),
-    )
-
-  let decoded_result = gleojson.geojson_decoder(invalid_dynamic)
-
-  decoded_result
+  dynamic.from(
+    dict.from_list([
+      #("type", dynamic.from("InvalidType")),
+      #("coordinates", dynamic.from([1.0, 2.0])),
+    ]),
+  )
+  |> gleojson.geojson_decoder
   |> should.be_error
 }
 
 pub fn invalid_coordinates_decode_test() {
-  let invalid_dynamic =
-    dynamic.from(
-      dict.from_list([
-        #("type", dynamic.from("Point")),
-        #("coordinates", dynamic.from("invalid coordinates")),
-      ]),
-    )
-
-  let decoded_result = gleojson.geojson_decoder(invalid_dynamic)
-
-  decoded_result
+  dynamic.from(
+    dict.from_list([
+      #("type", dynamic.from("Point")),
+      #("coordinates", dynamic.from("invalid coordinates")),
+    ]),
+  )
+  |> gleojson.geojson_decoder
   |> should.be_error
 }
 


### PR DESCRIPTION
BREAKING_CHANGE:
`encode_geojson` function was generating `dynamic.Dynamic` which is pretty useless from consumer standpoint. Now it is refactored to generate `Json` type which can be stringified with `json.to_string`.

Note: currently intentionally left encoding arbitrary `Feature` properties unimplemented.